### PR TITLE
Make wiki-creation/changing linkify bugs from issues.

### DIFF
--- a/releasewarrior/commands.py
+++ b/releasewarrior/commands.py
@@ -13,6 +13,7 @@ from releasewarrior.helpers import ensure_branch_and_version_are_valid, release_
 from releasewarrior.helpers import get_remaining_tasks_ordered
 from releasewarrior.helpers import get_update_data, data_unchanged, get_complete_releases
 from releasewarrior.helpers import get_incomplete_releases
+from releasewarrior.helpers import convert_bugs_to_links
 from releasewarrior.config import REPO_PATH, RELEASES_PATH, TEMPLATES_PATH, ARCHIVED_RELEASES_PATH
 from releasewarrior.config import DATA_TEMPLATES, WIKI_TEMPLATES, POSTMORTEMS_PATH
 
@@ -60,6 +61,7 @@ class Command(metaclass=abc.ABCMeta):
         """generates wiki file based on data file and wiki template"""
         env = Environment(loader=FileSystemLoader(TEMPLATES_PATH),
                           undefined=StrictUndefined, trim_blocks=True)
+        data['issues'] = convert_bugs_to_links(data['issues'])
         template = env.get_template(wiki_template)
         return template.render(**data)
 

--- a/releasewarrior/helpers.py
+++ b/releasewarrior/helpers.py
@@ -8,6 +8,9 @@ from releasewarrior.config import RELEASES_PATH, ARCHIVED_RELEASES_PATH
 
 logger = logging.getLogger('releasewarrior')
 
+BUG_RE = r'(?<!\[)\b[bB][uU][gG]\s*(\d+)(?!\]\(http)\b'  # Don't match already linked bugs
+BUG_REPLACE = r'[Bug \1](https://bugzil.la/\1)'
+
 
 def get_current_releases():
     current_releases = {}
@@ -135,3 +138,13 @@ def get_remaining_tasks_ordered(release_human_tasks):
     # this is a hack because ORDERED_HUMAN_TASKS is hardcoded and may get out of date
     remaining_tasks = [task for task, done in release_human_tasks.items() if not done]
     return [ordered_task for ordered_task in ORDERED_HUMAN_TASKS if ordered_task in remaining_tasks]
+
+
+def convert_bugs_to_links(arr_of_strings):
+    """ This function linkifies Bug entries in issue lists for formatting into
+        markdown format.
+    """
+    new_data = []
+    for item in arr_of_strings:
+        new_data.append(re.sub(BUG_RE, BUG_REPLACE, item))
+    return new_data


### PR DESCRIPTION
This has been annoying me...

@lundjordan r?

```
>>> test
['bug 12345', 'Bug 12345', '[bug 12345]', 'Bug 1234,Bug 12345 ', '[Bug 12345] - ', 'no bug number', 'bug XYZ', '[BUG XYZ]', 'BUG 12345', '[BUG 12345] - foo', '[[Bug 12345](https://bugzil.la/12345)] - foo']
>>> for b in test:
...     re.sub(r'(?<!\[)\b[bB][uU][gG]\s*(\d+)(?!\]\(http)\b', r'[Bug \1](https://bugzil.la/\1)', b)
... 
'[Bug 12345](https://bugzil.la/12345)'
'[Bug 12345](https://bugzil.la/12345)'
'[bug 12345]'
'[Bug 1234](https://bugzil.la/1234),[Bug 12345](https://bugzil.la/12345) '
'[Bug 12345] - '
'no bug number'
'bug XYZ'
'[BUG XYZ]'
'[Bug 12345](https://bugzil.la/12345)'
'[BUG 12345] - foo'
'[[Bug 12345](https://bugzil.la/12345)] - foo'
```
