### PR TITLE
Add SSE deprecation bugs to precreated templates

### DIFF
--- a/releases/firefox-beta-49.0b1.json
+++ b/releases/firefox-beta-49.0b1.json
@@ -10,7 +10,9 @@
                 "published_balrog": false,
                 "submitted_shipit": false
             },
-            "issues": []
+            "issues": [
+                "SPECIAL REQUIREMENT: [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284901)"
+            ]
         }
     ],
     "date": "2016-07-08",

--- a/releases/firefox-beta-49.0b1.json
+++ b/releases/firefox-beta-49.0b1.json
@@ -1,0 +1,19 @@
+{
+    "builds": [
+        {
+            "aborted": false,
+            "buildnum": 1,
+            "graphid": "",
+            "human_tasks": {
+                "emailed_cdntest": false,
+                "post_released": false,
+                "published_balrog": false,
+                "submitted_shipit": false
+            },
+            "issues": []
+        }
+    ],
+    "date": "2016-07-08",
+    "product": "firefox",
+    "version": "49.0b1"
+}

--- a/releases/firefox-beta-49.0b1.md
+++ b/releases/firefox-beta-49.0b1.md
@@ -11,6 +11,7 @@ task graph url: unknown
 #### Status
 - [ ] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
 - [ ] [emailed beta-cdntest](../how-tos/relpro.md#1-email-drivers-re-release-live-on-cdntest-channel)
+- [_] [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284901)
 - [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
 - [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
 

--- a/releases/firefox-beta-49.0b1.md
+++ b/releases/firefox-beta-49.0b1.md
@@ -1,0 +1,20 @@
+# Beta: Firefox 49.0b1
+
+### Started: 2016-07-08
+
+## Build 1
+
+### Beta Graph
+task graph url: unknown
+
+
+#### Status
+- [ ] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
+- [ ] [emailed beta-cdntest](../how-tos/relpro.md#1-email-drivers-re-release-live-on-cdntest-channel)
+- [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
+- [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
+
+### Issues
+- none
+
+

--- a/releases/firefox-beta-49.0b1.md
+++ b/releases/firefox-beta-49.0b1.md
@@ -11,11 +11,10 @@ task graph url: unknown
 #### Status
 - [ ] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
 - [ ] [emailed beta-cdntest](../how-tos/relpro.md#1-email-drivers-re-release-live-on-cdntest-channel)
-- [_] [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284901)
 - [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
 - [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
 
 ### Issues
-- none
+- [_] SPECIAL REQUIREMENT: [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284901)
 
 

--- a/releases/firefox-esr-45.3.0esr.json
+++ b/releases/firefox-esr-45.3.0esr.json
@@ -1,0 +1,20 @@
+{
+    "builds": [
+        {
+            "aborted": false,
+            "buildnum": 1,
+            "graphid": "",
+            "graphid_2": "",
+            "human_tasks": {
+                "post_released": false,
+                "published_balrog": false,
+                "pushed_mirrors": false,
+                "submitted_shipit": false
+            },
+            "issues": []
+        }
+    ],
+    "date": "2016-07-08",
+    "product": "firefox",
+    "version": "45.3.0esr"
+}

--- a/releases/firefox-esr-45.3.0esr.json
+++ b/releases/firefox-esr-45.3.0esr.json
@@ -11,7 +11,9 @@
                 "pushed_mirrors": false,
                 "submitted_shipit": false
             },
-            "issues": []
+            "issues": [
+                "SPECIAL REQUIREMENT: [set-up Windows watershed update](https://bugzilla.mozilla.org/show_bug.cgi?id=1284904)"
+            ]
         }
     ],
     "date": "2016-07-08",

--- a/releases/firefox-esr-45.3.0esr.md
+++ b/releases/firefox-esr-45.3.0esr.md
@@ -16,10 +16,8 @@ task graph url: unknown
 #### Status
 - [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
 - [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
-- [_] [set-up Windows watershed update](https://bugzilla.mozilla.org/show_bug.cgi?id=1284904)
 - [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
 
 ### Issues
-- none
-
+- [_] SPECIAL REQUIREMENT: [set-up Windows watershed update](https://bugzilla.mozilla.org/show_bug.cgi?id=1284904)
 

--- a/releases/firefox-esr-45.3.0esr.md
+++ b/releases/firefox-esr-45.3.0esr.md
@@ -16,6 +16,7 @@ task graph url: unknown
 #### Status
 - [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
 - [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
+- [_] [set-up Windows watershed update](https://bugzilla.mozilla.org/show_bug.cgi?id=1284904)
 - [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
 
 ### Issues

--- a/releases/firefox-esr-45.3.0esr.md
+++ b/releases/firefox-esr-45.3.0esr.md
@@ -1,0 +1,24 @@
+# ESR: Firefox 45.3.0esr
+
+### Started: 2016-07-08
+
+## Build 1
+
+### ESR Graph 1
+task graph url: unknown
+
+#### Status
+- [ ] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
+
+### ESR Graph 2
+task graph url: unknown
+
+#### Status
+- [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
+- [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
+- [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
+
+### Issues
+- none
+
+

--- a/releases/firefox-esr-52.3.0esr.json
+++ b/releases/firefox-esr-52.3.0esr.json
@@ -1,0 +1,20 @@
+{
+    "builds": [
+        {
+            "aborted": false,
+            "buildnum": 1,
+            "graphid": "",
+            "graphid_2": "",
+            "human_tasks": {
+                "post_released": false,
+                "published_balrog": false,
+                "pushed_mirrors": false,
+                "submitted_shipit": false
+            },
+            "issues": []
+        }
+    ],
+    "date": "2016-07-08",
+    "product": "firefox",
+    "version": "52.3.0esr"
+}

--- a/releases/firefox-esr-52.3.0esr.json
+++ b/releases/firefox-esr-52.3.0esr.json
@@ -11,7 +11,9 @@
                 "pushed_mirrors": false,
                 "submitted_shipit": false
             },
-            "issues": []
+            "issues": [
+                "SPECIAL REQUIREMENT: [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284906)"
+            ]
         }
     ],
     "date": "2016-07-08",

--- a/releases/firefox-esr-52.3.0esr.md
+++ b/releases/firefox-esr-52.3.0esr.md
@@ -15,6 +15,7 @@ task graph url: unknown
 
 #### Status
 - [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
+- [_] [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284906)
 - [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
 - [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
 

--- a/releases/firefox-esr-52.3.0esr.md
+++ b/releases/firefox-esr-52.3.0esr.md
@@ -15,11 +15,10 @@ task graph url: unknown
 
 #### Status
 - [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
-- [_] [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284906)
 - [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
 - [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
 
 ### Issues
-- none
+- [_] SPECIAL REQUIREMENT: [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284906)
 
 

--- a/releases/firefox-esr-52.3.0esr.md
+++ b/releases/firefox-esr-52.3.0esr.md
@@ -1,0 +1,24 @@
+# ESR: Firefox 52.3.0esr
+
+### Started: 2016-07-08
+
+## Build 1
+
+### ESR Graph 1
+task graph url: unknown
+
+#### Status
+- [ ] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
+
+### ESR Graph 2
+task graph url: unknown
+
+#### Status
+- [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
+- [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
+- [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
+
+### Issues
+- none
+
+

--- a/releases/firefox-release-48.0.json
+++ b/releases/firefox-release-48.0.json
@@ -12,7 +12,8 @@
             },
             "issues": [
                 "SPECIAL REQUIREMENT: Do [Bug 1275607](https://bugzil.la/1275607) - add OS X 10.6-10.8 deprecation rule when 48.0 ships to release",
-                "SPECIAL REQUIREMENT: Delete RuleID 366 and 367 (firefox, release channel) to allow updates to 48.0 from 47.0 when ready to go live"
+                "SPECIAL REQUIREMENT: Delete RuleID 366 and 367 (firefox, release channel) to allow updates to 48.0 from 47.0 when ready to go live",
+                "SPECIAL REQUIREMENT: [set-up Windows watershed update](https://bugzilla.mozilla.org/show_bug.cgi?id=1284903) before shipping"
             ]
         }
     ],

--- a/releases/firefox-release-48.0.md
+++ b/releases/firefox-release-48.0.md
@@ -10,10 +10,10 @@ task graph url: unknown
 #### Status
 - [ ] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
 - [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
-- [_] [create OS X 10.6-10.8 deprecation rule](https://bugzil.la/1275607)
 - [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
-- [_] delete rule ids 366 and 367 in Balrog to allow 47.0 -> 48.0 updates
-- [_] [set-up Windows watershed update](https://bugzilla.mozilla.org/show_bug.cgi?id=1284903)
 - [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
 
 ### Issues
+- [_] SPECIAL REQUIREMENT: Do [Bug 1275607](https://bugzil.la/1275607) - add OS X 10.6-10.8 deprecation rule when 48.0 ships to release
+- [_] SPECIAL REQUIREMENT: Delete RuleID 366 and 367 (firefox, release channel) to allow updates to 48.0 from 47.0 when ready to go live
+- [_] SPECIAL REQUIREMENT: [set-up Windows watershed update](https://bugzilla.mozilla.org/show_bug.cgi?id=1284903) before shipping

--- a/releases/firefox-release-48.0.md
+++ b/releases/firefox-release-48.0.md
@@ -10,11 +10,10 @@ task graph url: unknown
 #### Status
 - [ ] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
 - [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
+- [_] [create OS X 10.6-10.8 deprecation rule](https://bugzil.la/1275607)
 - [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
+- [_] delete rule ids 366 and 367 in Balrog to allow 47.0 -> 48.0 updates
+- [_] [set-up Windows watershed update](https://bugzilla.mozilla.org/show_bug.cgi?id=1284903)
 - [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
 
 ### Issues
-- SPECIAL REQUIREMENT: Do [Bug 1275607](https://bugzil.la/1275607) - add OS X 10.6-10.8 deprecation rule when 48.0 ships to release
-- SPECIAL REQUIREMENT: Delete RuleID 366 and 367 (firefox, release channel) to allow updates to 48.0 from 47.0 when ready to go live
-
-

--- a/releases/firefox-release-49.0.json
+++ b/releases/firefox-release-49.0.json
@@ -1,0 +1,19 @@
+{
+    "builds": [
+        {
+            "aborted": false,
+            "buildnum": 1,
+            "graphid": "",
+            "human_tasks": {
+                "post_released": false,
+                "published_balrog": false,
+                "pushed_mirrors": false,
+                "submitted_shipit": false
+            },
+            "issues": []
+        }
+    ],
+    "date": "2016-07-08",
+    "product": "firefox",
+    "version": "49.0"
+}

--- a/releases/firefox-release-49.0.json
+++ b/releases/firefox-release-49.0.json
@@ -10,7 +10,9 @@
                 "pushed_mirrors": false,
                 "submitted_shipit": false
             },
-            "issues": []
+            "issues": [
+                "SPECIAL REQUIREMENT: [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284905)"
+            ]
         }
     ],
     "date": "2016-07-08",

--- a/releases/firefox-release-49.0.md
+++ b/releases/firefox-release-49.0.md
@@ -10,6 +10,7 @@ task graph url: unknown
 #### Status
 - [ ] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
 - [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
+- [_] [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284905)
 - [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
 - [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
 

--- a/releases/firefox-release-49.0.md
+++ b/releases/firefox-release-49.0.md
@@ -10,11 +10,9 @@ task graph url: unknown
 #### Status
 - [ ] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
 - [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
-- [_] [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284905)
 - [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
 - [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
 
 ### Issues
-- none
-
+- [_] SPECIAL REQUIREMENT: [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284905)
 

--- a/releases/firefox-release-49.0.md
+++ b/releases/firefox-release-49.0.md
@@ -1,0 +1,19 @@
+# Release: Firefox 49.0
+
+### Started: 2016-07-08
+
+## Build 1
+
+### Release Graph
+task graph url: unknown
+
+#### Status
+- [ ] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
+- [ ] [pushed to mirrors/releases](../how-tos/relpro.md#2-push-to-releases-dir-mirrors)
+- [ ] [publish in Balrog](../how-tos/relpro.md#3-publish-in-balrog)
+- [ ] [post-release tasks](../how-tos/relpro.md#4-post-release-step)
+
+### Issues
+- none
+
+


### PR DESCRIPTION
I'm told that this is how we prefer to track "special stuff that needs to be done as part of releases" these days, like the OS X deprecation stuff that @Callek added to the 48.0 template.

I did the same for all upcoming SSE deprecation stuff listed in https://bugzilla.mozilla.org/show_bug.cgi?id=1271762#c18. I thought it would be better to integrate with the "status" section, because certain things have to happen at certain times of the release, so it's good to put them in order now. This is what we used to do back in the day with wiki build notes. I can change that if it's unwanted, though.

Not sure who the right person to review this is, @rail, @lundjordan, @nthomas-mozilla, @kmoir, @Callek?
