### PR TITLE
Add instructions for remaining OS X deprecation work.

### DIFF
--- a/releases/FUTURE/firefox-esr-45.8.0esr.json
+++ b/releases/FUTURE/firefox-esr-45.8.0esr.json
@@ -1,0 +1,5 @@
+{
+    "issues": [
+        "SPECIAL REQUIREMENT: [add OS X watershed rule when 45.8.0esr ships](https://bugzilla.mozilla.org/show_bug.cgi?id=1275609)"
+    ]
+}

--- a/releases/FUTURE/firefox-esr-52.3.0esr.json
+++ b/releases/FUTURE/firefox-esr-52.3.0esr.json
@@ -1,5 +1,6 @@
 {
     "issues": [
-        "SPECIAL REQUIREMENT: [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284906)"
+        "SPECIAL REQUIREMENT: [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284906)",
+        "SPECIAL REQUIREMENT: [add OS X 10.6-10.8 deprecation rule before 52.3.0 ships to esr](https://bugzilla.mozilla.org/show_bug.cgi?id=1293777)"
     ]
 }

--- a/releases/FUTURE/firefox-release-rc-49.0.json
+++ b/releases/FUTURE/firefox-release-rc-49.0.json
@@ -1,6 +1,7 @@
 {
   "issues": [
     "SPECIAL REQUIREMENT: [block non-SSE2 Windows updates](https://bugzilla.mozilla.org/show_bug.cgi?id=1284905)",
+    "SPECIAL REQUIREMENT: [add OS X 10.6-10.8 deprecation rule before 49.0 ships to release](https://bugzilla.mozilla.org/show_bug.cgi?id=1275607)",
     "SPECIAL REQUIREMENT: [Set up a Whats New Page for zh-TW](https://bugzilla.mozilla.org/show_bug.cgi?id=1292637)"
   ]
 }


### PR DESCRIPTION
This comes out of https://bugzilla.mozilla.org/show_bug.cgi?id=1292165, where we discovered that we can't add the deprecation rules as early as I thought. We can still add the watershed rules early, so may as well do that, but the deprecation rules must be added just _before_ we ship the first unsupported release.

@Callek - I know you suggested tweaking the 48.0 file, but I don't want to alter history....we did those things, and we probably shouldn't try to pretend we didn't.
