### PR TITLE
Use develop so we get code changes as well as data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,22 +7,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
-.Python
-env/
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
 *.egg-info/
-.installed.cfg
-*.egg
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ cd releasewarrior
 install it in your virtual python environment
 ```
 mkvirtualenv --python=/path/to/python3 releasewarrior
-python setup.py install
+python setup.py develop
 ```
+Using the develop target ensures that you get code updates along with data when pulling in changes.
 
 ## Overview Flow
 

--- a/how-tos/relpro.md
+++ b/how-tos/relpro.md
@@ -66,13 +66,13 @@ python src/tctalker/tctalker.py --conf config.json <action> <task-id>
 
 ### how
 * Desktop Firefox Betas
-    * email release-drivers@mozilla.com with subject only email `[desktop] Firefox Beta $version updates are available on the beta-cdntest channel now <EOM>`
+    * email release-drivers@mozilla.org with subject only email `[desktop] Firefox Beta $version updates are available on the beta-cdntest channel now <EOM>`
 * Desktop Firefox Release-Candidates
-    * email release-drivers@mozilla.com with subject only email `[desktop] Firefox RC Release $version updates are available on the beta-cdntest channel now <EOM>`
+    * email release-drivers@mozilla.org with subject only email `[desktop] Firefox RC Release $version updates are available on the beta-cdntest channel now <EOM>`
 * Desktop Firefox Releases (dot releases)
-    * email release-drivers@mozilla.com with subject only email `[desktop] Firefox Release $version updates are available on the release-localtest channel now <EOM>`
+    * email release-drivers@mozilla.org with subject only email `[desktop] Firefox Release $version updates are available on the release-localtest channel now <EOM>`
 * Desktop Firefox ESRs
-    * email release-drivers@mozilla.com with subject only email `[desktop] Firefox ESR $version updates are available on the esr-localtest channel now <EOM>`
+    * email release-drivers@mozilla.org with subject only email `[desktop] Firefox ESR $version updates are available on the esr-localtest channel now <EOM>`
 
 
 ## 2. push to releases dir (mirrors)


### PR DESCRIPTION
Updates the README to suggest `python setup.py develop` instead of install, so that code changes are active after git pulls. Attempts to adjust .gitignore for that. Also fixes the r-d email address.
