### PR TITLE
Supress python-git verbose logging, print build#

### DIFF
--- a/releasewarrior/__main__.py
+++ b/releasewarrior/__main__.py
@@ -19,6 +19,7 @@ def setup_logging():
     # flip this to INFO once done testing
     console.setLevel(logging.DEBUG)
     console.setFormatter(logging.Formatter('%(message)s'))
+    logging.getLogger('git').setLevel(logging.WARNING)
 
     # add console logging to root logger
     logging.getLogger('').addHandler(console)

--- a/releasewarrior/commands.py
+++ b/releasewarrior/commands.py
@@ -362,7 +362,9 @@ class Status(Command):
             curr_build = release["builds"][-1]
             issues = [issue for issue in curr_build["issues"]]
 
-            logger.info("RELEASE IN FLIGHT: %s %s %s", release["product"], release["version"], release["date"])
+            logger.info("RELEASE IN FLIGHT: %s %s %s build%s",
+                release["product"], release["version"], curr_build["buildnum"],
+                release["date"])
             if "graphid" in curr_build:
                 logger.info("Graph: https://tools.taskcluster.net/push-inspector/#/%s ", curr_build["graphid"])
             logger.info("\tincomplete human tasks:")


### PR DESCRIPTION
I recreated my virtualenv and started getting annoying logging like
```
RUNNING with args: status
getting incomplete releases
Popen(['git', 'diff', '--cached', '--abbrev=40', '--full-index', '--raw'], cwd=/home/rail/work/mozilla/git/releasewarrior, universal_newlines=False, shell=None)
Popen(['git', 'diff', '--abbrev=40', '--full-index', '--raw'], cwd=/home/rail/work/mozilla/git/releasewarrior, universal_newlines=False, shell=None)
```

This PR fixes that and also print the current build# in `release status` output.

@lundjordan r?