### PR TITLE
Filter release status

### DIFF
--- a/releasewarrior/__main__.py
+++ b/releasewarrior/__main__.py
@@ -105,6 +105,11 @@ def parse_args():
     parser_postmortem.add_argument('date', type=lambda x: datetime.datetime.strptime(x, "%Y-%m-%d"),
                                    help='the date of the upcoming postmortem meeting')
 
+    # status options
+    parser_status.add_argument(
+        'pattern', nargs='?', metavar='REGEX',
+         help='Filter releases using a regex. The search is performed in "{product} {version}"')
+
     return parser.parse_args()
 
 

--- a/releasewarrior/commands.py
+++ b/releasewarrior/commands.py
@@ -4,6 +4,7 @@ import sys
 import logging
 import json
 import datetime
+import re
 from copy import deepcopy
 
 from git import Repo
@@ -343,6 +344,7 @@ class Postmortem(Command):
 class Status(Command):
 
     def __init__(self, args):
+        self.pattern = args.pattern
         self.incomplete_releases = get_incomplete_releases()
         self.pre_run_check()
 
@@ -358,6 +360,12 @@ class Status(Command):
     def run(self):
 
         for release in self.incomplete_releases.values():
+            if self.pattern:
+                if not re.search(
+                        self.pattern,
+                        "{} {}".format(release["product"], release["version"]),
+                        flags=re.IGNORECASE):
+                    continue
             remaining_tasks_ordered = get_remaining_tasks_ordered(release["builds"][-1]["human_tasks"])
             curr_build = release["builds"][-1]
             issues = [issue for issue in curr_build["issues"]]


### PR DESCRIPTION
Really helps when you have more than 2-3 releases in flight.
```
$ release status -h            
usage: release status [-h] [REGEX]

positional arguments:
  REGEX       Filter releases using a regex. The search is performed in
              "{product} {version}"

optional arguments:
  -h, --help  show this help message and exit

$ release status '^firefox.*7$'            
RUNNING with args: status ^firefox.*7$
getting incomplete releases
ensuring releasewarrior repo is up to date and in sync with origin
fetching new csets from origin to origin/master
===============================================================================
RELEASE IN FLIGHT: firefox 51.0b7 build1 2016-12-12
Graph: https://tools.taskcluster.net/push-inspector/#/mp0Fij92SbS8QyOgvrrUqg
        incomplete human tasks:
                * emailed_cdntest
                * published_release
        latest issues:
```