### PR TITLE
Add missing steps for triggering Fennec graph via releasetasks

### DIFF
--- a/how-tos/fennec-temp-relpro.md
+++ b/how-tos/fennec-temp-relpro.md
@@ -15,20 +15,38 @@ These steps are meant to be specifically for Fennec-53.0b1.
 
 ## Noop ship-it
 
-Nothing to do here. Yay!
+Nothing to do here but notice there should be a Fennec build under [this section](https://ship-it.mozilla.org/releases.html#reviewed-tab)
+Grab the `builduild number`, the `revision` and the `version` from the Ship-it entry.
 
 ## Skip source
 
-Nothing to do here for the moment. Both in the releasetasks generated graph and the hook, the source builder shall be turned off.
+Nothing to do here for the moment. The source builder needs to be fixed so for the moment it is turned off.
 
-## Kick off fennec_candidates hook
+## Start off the Fenenc graph
 
-The hook that triggers the Fennec graph is [here](https://tools.taskcluster.net/hooks/#project-releng/candidates-fennec-beta).
-* alter GECKO_HEAD_REF, GECKO_HEAD_REV to corresponding changeset from Ship-it
-* bump the buildnumber to correspond to Ship-it
-* trigger hook!
+The way this works is we trigger a graph that contains most of the builders (sans source builder, checksums and others which are still under development).
+One of the tasks is a decision task which will at its turn generate another graph for which all the tasks
+will have their TaskGroupId set to the decision task. That is the nightly graph that builds, signs and beetmoves stuff to S3.
 
-## Hack candidates to release script, run manually
+1. Follow the following set of instructions:
+
+```bash
+$ ssh `whoami`@buildbot-master85.bb.releng.scl3.mozilla.com  # host we release-runner and you generate/submit new release promotion graphs
+$ sudo su - cltbld
+$ cd /home/cltbld/releasetasks/
+$ git pull origin master  # make sure we are up to date. note: make sure this is on master and clean first
+$ cd /builds/releaserunner/tools/buildfarm/release/
+$ hg pull -u # make sure we are up to date. note: make sure this is on default and clean first
+$ source /builds/releaserunner/bin/activate
+# call releasetasks_graph_gen.py with --dry-run and sanity check the graph output that would be submitted
+$ python releasetasks_graph_gen.py --release-runner-ini=../../../release-runner.ini --branch-and-product-config=/home/cltbld/releasetasks/releasetasks/release_configs/prod_mozilla-beta_fennec_full_graph.yml  --version TODO --build-number TODO --mozilla-revision TODO --dry-run
+# call releasetasks_graph_gen.py for reals which will submit the graph to Taskcluster
+$ python releasetasks_graph_gen.py --release-runner-ini=../../../release-runner.ini --branch-and-product-config=/home/cltbld/releasetasks/releasetasks/release_configs/prod_mozilla-beta_fennec_full_graph.yml  --version TODO --build-number TODO --mozilla-revision TODO
+```
+
+2. The resulted graphid should be tracked in releasewarrior
+3. Once the decision-task generated graph is green and all artifacts are under [candidates](http://archive.mozilla.org/pub/mobile/candidates/) for that given version, send a heads-up email like [this](https://github.com/mozilla/releasewarrior/blob/master/how-tos/relpro.md#why)
+to release drivers specifying the updates are now available on the `beta-localtest` channel.
 
 ## Run pushapk manually
 

--- a/how-tos/fennec-temp-relpro.md
+++ b/how-tos/fennec-temp-relpro.md
@@ -55,6 +55,9 @@ The hook that triggers the Fennec graph is [here](https://tools.taskcluster.net/
 * bump the buildnumber to correspond to Ship-it
 * trigger hook!
 
+If this is the solution you end up doing - we will also need the following:
+* trigger another subgraph containing all the steps after push-to-releases, included. This can be done similarly with the above commands via releasetasks, but toggling to `False` all variables from [here](https://github.com/mozilla/releasetasks/blob/master/releasetasks/release_configs/prod_mozilla-beta_fennec_full_graph.yml)
+
 ## Run pushapk manually
 
 ### Use pushapk_scriptworker

--- a/how-tos/fennec-temp-relpro.md
+++ b/how-tos/fennec-temp-relpro.md
@@ -47,6 +47,14 @@ $ python releasetasks_graph_gen.py --release-runner-ini=../../../release-runner.
 * Once the decision-task generated graph is green and all artifacts are under [candidates](http://archive.mozilla.org/pub/mobile/candidates/) for that given version, send a heads-up email like [this](https://github.com/mozilla/releasewarrior/blob/master/how-tos/relpro.md#why)
 to release drivers specifying the updates are now available on the `beta-localtest` channel.
 
+** Disclaimer **
+
+If for some reason any of the steps above fail, we still have a fall-back option by using the manual hook to trigger the nightly graph that will ensure the build/signing/beetmoving artifacts to S3.
+The hook that triggers the Fennec graph is [here](https://tools.taskcluster.net/hooks/#project-releng/candidates-fennec-beta).
+* alter GECKO_HEAD_REF, GECKO_HEAD_REV to corresponding changeset from Ship-it
+* bump the buildnumber to correspond to Ship-it
+* trigger hook!
+
 ## Run pushapk manually
 
 ### Use pushapk_scriptworker

--- a/how-tos/fennec-temp-relpro.md
+++ b/how-tos/fennec-temp-relpro.md
@@ -47,7 +47,7 @@ $ python releasetasks_graph_gen.py --release-runner-ini=../../../release-runner.
 * Once the decision-task generated graph is green and all artifacts are under [candidates](http://archive.mozilla.org/pub/mobile/candidates/) for that given version, send a heads-up email like [this](https://github.com/mozilla/releasewarrior/blob/master/how-tos/relpro.md#why)
 to release drivers specifying the updates are now available on the `beta-localtest` channel.
 
-** Disclaimer **
+*Disclaimer*
 
 If for some reason any of the steps above fail, we still have a fall-back option by using the manual hook to trigger the nightly graph that will ensure the build/signing/beetmoving artifacts to S3.
 The hook that triggers the Fennec graph is [here](https://tools.taskcluster.net/hooks/#project-releng/candidates-fennec-beta).

--- a/how-tos/fennec-temp-relpro.md
+++ b/how-tos/fennec-temp-relpro.md
@@ -6,16 +6,15 @@ These steps are meant to be specifically for Fennec-53.0b1.
 
 1. noop ship-it
 2. skip source
-3. kick off fennec_candidates hook
-4. hack candidates to release script, run manually
-5. run pushapk manually
-6. mark release as shipped in ship-it
+3. start off the Fenenc graph
+4. run pushapk manually
+5. mark release as shipped in ship-it
 
 # Detailed descriptions
 
 ## Noop ship-it
 
-Nothing to do here but notice there should be a Fennec build under [this section](https://ship-it.mozilla.org/releases.html#reviewed-tab)
+Nothing to do here but notice there should be a Fennec build under [this section](https://ship-it.mozilla.org/releases.html#reviewed-tab).
 Grab the `builduild number`, the `revision` and the `version` from the Ship-it entry.
 
 ## Skip source
@@ -24,11 +23,11 @@ Nothing to do here for the moment. The source builder needs to be fixed so for t
 
 ## Start off the Fenenc graph
 
-The way this works is we trigger a graph that contains most of the builders (sans source builder, checksums and others which are still under development).
-One of the tasks is a decision task which will at its turn generate another graph for which all the tasks
+The way this works is by triggering a graph that contains most of the builders (sans source builder, checksums and others which are still under development).
+One of the tasks is a `decision task` which will, at its turn, generate another graph for which all the tasks
 will have their TaskGroupId set to the decision task. That is the nightly graph that builds, signs and beetmoves stuff to S3.
 
-1. Follow the following set of instructions:
+* Follow the following set of instructions:
 
 ```bash
 $ ssh `whoami`@buildbot-master85.bb.releng.scl3.mozilla.com  # host we release-runner and you generate/submit new release promotion graphs
@@ -44,8 +43,8 @@ $ python releasetasks_graph_gen.py --release-runner-ini=../../../release-runner.
 $ python releasetasks_graph_gen.py --release-runner-ini=../../../release-runner.ini --branch-and-product-config=/home/cltbld/releasetasks/releasetasks/release_configs/prod_mozilla-beta_fennec_full_graph.yml  --version TODO --build-number TODO --mozilla-revision TODO
 ```
 
-2. The resulted graphid should be tracked in releasewarrior
-3. Once the decision-task generated graph is green and all artifacts are under [candidates](http://archive.mozilla.org/pub/mobile/candidates/) for that given version, send a heads-up email like [this](https://github.com/mozilla/releasewarrior/blob/master/how-tos/relpro.md#why)
+* The resulted graphid should be tracked in releasewarrior
+* Once the decision-task generated graph is green and all artifacts are under [candidates](http://archive.mozilla.org/pub/mobile/candidates/) for that given version, send a heads-up email like [this](https://github.com/mozilla/releasewarrior/blob/master/how-tos/relpro.md#why)
 to release drivers specifying the updates are now available on the `beta-localtest` channel.
 
 ## Run pushapk manually

--- a/how-tos/fennec-temp-relpro.md
+++ b/how-tos/fennec-temp-relpro.md
@@ -55,7 +55,7 @@ The hook that triggers the Fennec graph is [here](https://tools.taskcluster.net/
 * bump the buildnumber to correspond to Ship-it
 * trigger hook!
 
-If this is the solution you end up doing - we will also need the following:
+*If this is the solution you end up doing - we will also need the following*:
 * trigger another subgraph containing all the steps after push-to-releases, included. This can be done similarly with the above commands via releasetasks, but toggling to `False` all variables from [here](https://github.com/mozilla/releasetasks/blob/master/releasetasks/release_configs/prod_mozilla-beta_fennec_full_graph.yml)
 
 ## Run pushapk manually


### PR DESCRIPTION
@escapewindow 

If we feel we're courageos enough, we could schedule Fennec 53.0b2 via the releasetasks. All the tasks are contained within a single graph now, sans few builders that are still known to have issues.

I've updated the docs steps here but I wouldn't rush into merging the PR until we've successfully tested this method against a release to see it works (well, I mean a real release, I've alredy played with a staging one). Alternatively, we have the hook + tweaking the graph to only do the second graph.

Since the Go-to-build is coming most likely late on PST timezone, I thought you might give this a try and if it works, please merge the PR. If it doesn't, we can use the hook. 