### PR TITLE
Add note to remind releaseduty to update signoff rule in Balrog.

### DIFF
--- a/templates/firefox_beta.md.tmpl
+++ b/templates/firefox_beta.md.tmpl
@@ -17,6 +17,7 @@ task graph url: unknown
 - [{% if build["human_tasks"]['submitted_shipit'] %}x{% else %} {% endif %}] [submit to Shipit](https://wiki.mozilla.org/Release:Release_Automation_on_Mercurial:Starting_a_Release#Submit_to_Ship_It)
 - [{% if build["human_tasks"]['emailed_cdntest'] %}x{% else %} {% endif %}] [emailed beta-cdntest](../how-tos/relpro.md#1-email-drivers-re-release-live-on-test-channel)
 - [{% if build["human_tasks"]['published_release'] %}x{% else %} {% endif %}] [published release tasks](../how-tos/relpro.md#3-publish-release)
+- [{% if build["human_tasks"]['published_release'] %}x{% else %} {% endif %}] Update "Firefoxsignoff" rule in Balrog
 
 ### Issues
 {% for issue in build['issues'] %}


### PR DESCRIPTION
I thought about putting this in the actual docs section (https://github.com/mozilla/releasewarrior/blob/master/how-tos/relpro.md#3-publish-release), but I thought putting it here might be a better reminder - I'm not sure if the docs are consulted for every release.

We'll need additional updates here when we move to the second stage of the rollout, where signoffs will be required for Firefox's beta channel.