### PR TITLE
add --checkbox arg

### DIFF
--- a/releasewarrior/__main__.py
+++ b/releasewarrior/__main__.py
@@ -6,7 +6,7 @@ import logging
 
 from releasewarrior.commands import CreateRelease, UpdateRelease, Postmortem, Status
 from releasewarrior.commands import SyncRelease
-from releasewarrior.config import LOG_PATH
+from releasewarrior.config import ALL_CHECKBOXES, LOG_PATH
 
 
 def setup_logging():
@@ -75,6 +75,8 @@ def parse_args():
                                help='taskcluster graphid used for release in question')
     parser_update.add_argument('--graphid-2', '--taskcluster-graphid-2', dest='graphid_2',
                                help='taskcluster graphid used for graph 2 of rc release in question')
+    parser_update.add_argument('--checkbox', choices=ALL_CHECKBOXES, dest='checkboxes',
+                               help='Check off a human task')
     parser_update.add_argument('--shipit', '--submitted-shipit',
                                action='store_true', dest='submitted_shipit',
                                help='update release that we submitted to ship it (started release)')

--- a/releasewarrior/config.py
+++ b/releasewarrior/config.py
@@ -48,3 +48,17 @@ DATA_TEMPLATES = {
         'esr': os.path.join(TEMPLATES_PATH, 'thunderbird_esr.json.tmpl'),
     }
 }
+
+
+# The official json nick, followed by human-friendly alias(es)
+# These should be specified in order.
+KNOWN_CHECKBOXES = (
+    ('submitted_shipit', 'shipit'),
+    ('emailed_localtest', 'localtest'),
+    ('emailed_cdntest', 'cdntest'),
+    ('pushed_mirrors', 'mirrors'),
+    ('published_release', 'publish'),
+    ('published_rc_to_beta', 'beta'),
+)
+ALL_CHECKBOXES = tuple([item for sublist in KNOWN_CHECKBOXES for item in sublist])
+ORDERED_HUMAN_TASKS = tuple([sublist[0] for sublist in KNOWN_CHECKBOXES])


### PR DESCRIPTION
fixes #60.

This could use some more user friendliness, but it allows for easily adding more steps without having to add more command line options.