### PR TITLE
Fix when checkbox is not provided in command line

### DIFF
--- a/releasewarrior/helpers.py
+++ b/releasewarrior/helpers.py
@@ -70,7 +70,7 @@ def _get_checkbox_value(nick, args, special_arg=None):
         return (nick, True)
     aliases = [item for sublist in KNOWN_CHECKBOXES for item in sublist if nick == sublist[0]]
     for alias in aliases:
-        if alias in args.checkboxes:
+        if args.checkboxes and alias in args.checkboxes:
             return (nick, True)
     return (nick, False)
 


### PR DESCRIPTION
Follow up #62 

STR:
`releasewarrior update --issue 'my issue' firefox release 1.2.3`

Results:
``` py
Traceback (most recent call last):
  File "/home/jlorenzo/.virtualenvs/releasewarrior/bin/release", line 11, in <module>
    load_entry_point('releasewarrior', 'console_scripts', 'release')()
  File "/home/jlorenzo/git/mozilla/releasewarrior/releasewarrior/__main__.py", line 132, in main
    args.command(args).run()  # <3 argparse for this
  File "/home/jlorenzo/git/mozilla/releasewarrior/releasewarrior/commands.py", line 190, in __init__
    self.changes = get_update_data(args)
  File "/home/jlorenzo/git/mozilla/releasewarrior/releasewarrior/helpers.py", line 86, in get_update_data
    _get_checkbox_value("submitted_shipit", args, args.submitted_shipit),
  File "/home/jlorenzo/git/mozilla/releasewarrior/releasewarrior/helpers.py", line 73, in _get_checkbox_value
    if alias in args.checkboxes:
TypeError: argument of type 'NoneType' is not iterable
```