### PR TITLE
Add 'signoff' to all human task definitions.

### DIFF
--- a/releasewarrior/config.py
+++ b/releasewarrior/config.py
@@ -80,7 +80,7 @@ ORDERED_HUMAN_TASKS = (
     'cdntest',
     'mirrors',
     'pushapk',
+    'signoff',
     'publish',
     'beta',
-    'fxsignoff',
 )

--- a/templates/devedition.json.tmpl
+++ b/templates/devedition.json.tmpl
@@ -8,6 +8,7 @@
         "graphid": "",
         "human_tasks": {
           "shipit": false,
+          "signoff": false,
           "publish": false
         },
         "issues": []

--- a/templates/firefox_beta.json.tmpl
+++ b/templates/firefox_beta.json.tmpl
@@ -8,6 +8,7 @@
         "graphid": "",
         "human_tasks": {
           "shipit": false,
+          "signoff": false,
           "publish": false
         },
         "issues": []

--- a/templates/firefox_esr.json.tmpl
+++ b/templates/firefox_esr.json.tmpl
@@ -10,6 +10,7 @@
         "human_tasks": {
           "shipit": false,
           "mirrors": false,
+          "signoff": false,
           "publish": false
         },
         "issues": []

--- a/templates/firefox_release-rc.json.tmpl
+++ b/templates/firefox_release-rc.json.tmpl
@@ -11,6 +11,7 @@
           "shipit": false,
           "beta": false,
           "mirrors": false,
+          "signoff": false,
           "publish": false
         },
         "issues": []

--- a/templates/firefox_release.json.tmpl
+++ b/templates/firefox_release.json.tmpl
@@ -9,6 +9,7 @@
         "human_tasks": {
           "shipit": false,
           "mirrors": false,
+          "signoff": false,
           "publish": false
         },
         "issues": []

--- a/templates/thunderbird_beta.json.tmpl
+++ b/templates/thunderbird_beta.json.tmpl
@@ -7,6 +7,7 @@
         "aborted": false,
         "human_tasks": {
           "shipit": false,
+          "signoff": false,
           "publish": false
         },
         "issues": []

--- a/templates/thunderbird_release.json.tmpl
+++ b/templates/thunderbird_release.json.tmpl
@@ -8,6 +8,7 @@
         "human_tasks": {
           "shipit": false,
           "mirrors": false,
+          "signoff": false,
           "publish": false
         },
         "issues": []


### PR DESCRIPTION
@MihaiTabara discovered issues with my updates for multiple signoffs that lead to the backing out of #83. It boiled down to the fact that the markdown templates were looking for a "signoff" human task, but it didn't exist in many of the json files they depended on. I believe the issue boils down to the fact that the json files for active releases at the time were generated without "signoff" being a valid human decision task, and when the .md files are regenerated based on the new templates (which have references to a "signoff" human step), they fail.

To work around this, I think we should do a two stage landing of my original PR. This first landing will update config.py and all of the JSON templates. Once all of the active releases have the "signoff" human task in them, we can land part 2, which will update the .md templates and the docs.