### PR TITLE
Support ssh schemes for upstream repo

### DIFF
--- a/releasewarrior/commands.py
+++ b/releasewarrior/commands.py
@@ -22,7 +22,7 @@ from releasewarrior.config import DATA_TEMPLATES, WIKI_TEMPLATES, POSTMORTEMS_PA
 
 logger = logging.getLogger('releasewarrior')
 
-_UPSTREAM_REPO_URL = re.compile(r'(https://|git@)github\.com[:/]mozilla/releasewarrior(\.git)?')
+_UPSTREAM_REPO_URL = re.compile(r'((?:https|ssh)://|git@)github\.com[:/]mozilla/releasewarrior(\.git)?')
 _SIMPLIFIED_REPO_URL = 'github.com/mozilla/releasewarrior' # Used only to simplify what's logged out
 
 class Command(metaclass=abc.ABCMeta):


### PR DESCRIPTION
@Callek was blocked because his upstream repo is:
```
origin	ssh://github.com/mozilla/releasewarrior (fetch)
```


Follow up #42