### PR TITLE
Delete files in FUTURE/ when release is created

### DIFF
--- a/releasewarrior/commands.py
+++ b/releasewarrior/commands.py
@@ -155,7 +155,7 @@ class CreateRelease(Command):
                 data["builds"][0]["issues"] = json.load(future_data_file)["issues"]
 
             logger.info("removing FUTURE/ data file: {}".format(self.abs_future_data_file))
-            self.repo.index.remove([self.abs_future_data_file])
+            self.repo.index.remove([self.abs_future_data_file], working_tree=True)
 
         return data
 


### PR DESCRIPTION
Fixes #130.

GitPython made the fix fairly trivial: http://gitpython.readthedocs.io/en/stable/reference.html#git.index.base.IndexFile.remove. I didn't expect it to be that simple. I tested the fix manually (there's no automated tests in this project).